### PR TITLE
fix event dispatcher argument order

### DIFF
--- a/src/LuceneSearchBundle/Task/Parser/ParserTask.php
+++ b/src/LuceneSearchBundle/Task/Parser/ParserTask.php
@@ -441,8 +441,8 @@ class ParserTask extends AbstractTask
 
                 $parserEvent = new PdfParserEvent($doc, $fileContent, $assetMeta, $params);
                 $this->eventDispatcher->dispatch(
-                    LuceneSearchEvents::LUCENE_SEARCH_PARSER_PDF_DOCUMENT,
-                    $parserEvent
+                    $parserEvent,
+                    LuceneSearchEvents::LUCENE_SEARCH_PARSER_PDF_DOCUMENT
                 );
 
                 $doc = $parserEvent->getDocument();
@@ -621,8 +621,8 @@ class ParserTask extends AbstractTask
 
             $event = new AssetResourceRestrictionEvent($resource);
             $this->eventDispatcher->dispatch(
-                LuceneSearchEvents::LUCENE_SEARCH_PARSER_ASSET_RESTRICTION,
-                $event
+                $event,
+                LuceneSearchEvents::LUCENE_SEARCH_PARSER_ASSET_RESTRICTION
             );
 
             if ($event->getAsset() instanceof Asset) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2

follow-up to ea0cb4195b39f627588b0efa43c0a106f4b661b4, change argument order to match:

```php
public function dispatch(object $event, string $eventName = null): object
```