### PR TITLE
Update controller in routing.yml

### DIFF
--- a/src/LuceneSearchBundle/Resources/config/pimcore/routing.yml
+++ b/src/LuceneSearchBundle/Resources/config/pimcore/routing.yml
@@ -15,4 +15,4 @@ lucene_search.controller.admin.crawler.stop:
 # frontend
 lucene_search.controller.auto_complete.search:
     path: /lucence-search/auto-complete
-    defaults: { _controller: LuceneSearchBundle\Controller\AutoCompleteController:searchAction }
+    defaults: { _controller: LuceneSearchBundle\Controller\AutoCompleteController::searchAction }


### PR DESCRIPTION
Fixes the error: The controller for URI "/lucence-search/auto-complete" is not callable

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | o
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
