### PR TITLE
Dont index empty html

### DIFF
--- a/src/LuceneSearchBundle/Task/Parser/ParserTask.php
+++ b/src/LuceneSearchBundle/Task/Parser/ParserTask.php
@@ -330,6 +330,10 @@ class ParserTask extends AbstractTask
             'object_id'    => $objectId
         ];
 
+        if (!$html) {
+            $this->log(sprintf('not adding empty html from page: %s', $uri), 'error');
+            return false;
+        }
         $this->addHtmlToIndex($html, $originalHtml, $params);
 
         $this->log(sprintf('added html to indexer stack: %s', $uri));


### PR DESCRIPTION
The crawler currently aborts with an exception when somehow the HTML to be indexed is empty. This fix fill at least print an error an continue crawling.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
