### PR TITLE
Fix undefined array key and backend

### DIFF
--- a/src/LuceneSearchBundle/Command/CrawlCommand.php
+++ b/src/LuceneSearchBundle/Command/CrawlCommand.php
@@ -56,6 +56,8 @@ class CrawlCommand extends Command
             $this->taskManager->processTaskChain(['force' => $input->getOption('force')]);
         } catch (\Exception $e) {
             $output->writeln(sprintf('<fg=red>LuceneSearch: Error while crawling: %s.</>', $e->getMessage()));
+            $output->writeln(sprintf('<fg=red>- File: %s.</>', $e->getFile()));
+            $output->writeln(sprintf('<fg=red>- Line: %s.</>', $e->getLine()));
             return 1;
         }
 

--- a/src/LuceneSearchBundle/Controller/FrontendController.php
+++ b/src/LuceneSearchBundle/Controller/FrontendController.php
@@ -416,8 +416,8 @@ class FrontendController extends PimcoreFrontEndController
 
         $event = new RestrictionContextEvent();
         \Pimcore::getEventDispatcher()->dispatch(
-            LuceneSearchEvents::LUCENE_SEARCH_FRONTEND_RESTRICTION_CONTEXT,
-            $event
+            $event,
+            LuceneSearchEvents::LUCENE_SEARCH_FRONTEND_RESTRICTION_CONTEXT
         );
 
         try {

--- a/src/LuceneSearchBundle/LuceneSearchBundle.php
+++ b/src/LuceneSearchBundle/LuceneSearchBundle.php
@@ -21,7 +21,7 @@ class LuceneSearchBundle extends AbstractPimcoreBundle implements PimcoreBundleA
     /**
      * @inheritDoc
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new TaskPass());
         $container->addCompilerPass(new CategoriesPass());

--- a/src/LuceneSearchBundle/LuceneSearchBundle.php
+++ b/src/LuceneSearchBundle/LuceneSearchBundle.php
@@ -6,11 +6,14 @@ use LuceneSearchBundle\DependencyInjection\Compiler\CategoriesPass;
 use LuceneSearchBundle\DependencyInjection\Compiler\TaskPass;
 use LuceneSearchBundle\Tool\Install;
 use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
+use Pimcore\Extension\Bundle\PimcoreBundleAdminClassicInterface;
+use Pimcore\Extension\Bundle\Traits\BundleAdminClassicTrait;
 use Pimcore\Extension\Bundle\Traits\PackageVersionTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class LuceneSearchBundle extends AbstractPimcoreBundle
+class LuceneSearchBundle extends AbstractPimcoreBundle implements PimcoreBundleAdminClassicInterface
 {
+    use BundleAdminClassicTrait;
     use PackageVersionTrait;
 
     const PACKAGE_NAME = 'pringuin/pimcore-lucene-search';

--- a/src/LuceneSearchBundle/Resources/public/js/backend/settings.js
+++ b/src/LuceneSearchBundle/Resources/public/js/backend/settings.js
@@ -174,7 +174,7 @@ pimcore.plugin.luceneSearch.settings = Class.create({
 
                                                 window.setTimeout(function () {
                                                     _self.loadMask.hide();
-                                                }, 2000);
+                                                }, 5000);
                                             }
                                         });
                                     }.bind(this)

--- a/src/LuceneSearchBundle/Resources/public/js/backend/settings.js
+++ b/src/LuceneSearchBundle/Resources/public/js/backend/settings.js
@@ -18,8 +18,6 @@ pimcore.plugin.luceneSearch.settings = Class.create({
 
         var _ = this;
 
-        this.loadMask = false;
-
         if (!this.panel) {
 
             this.panel = Ext.create('Ext.panel.Panel', {
@@ -31,6 +29,11 @@ pimcore.plugin.luceneSearch.settings = Class.create({
                 layout: 'fit',
                 closable:true
 
+            });
+
+            this.loadMask = new Ext.LoadMask({
+                target: this.panel,
+                msg: t("please_wait")
             });
 
             var tabPanel = Ext.getCmp('pimcore_panel_tabs');
@@ -45,7 +48,6 @@ pimcore.plugin.luceneSearch.settings = Class.create({
             }.bind(this));
 
             this.container = Ext.create('Ext.Container', {
-
                 autoScroll: true,
                 scrollable: true,
                 layout: {
@@ -155,7 +157,7 @@ pimcore.plugin.luceneSearch.settings = Class.create({
                                                 } else {
 
                                                     button.setDisabled(false);
-                                                    _self.loadMask.hide();
+
                                                 }
 
                                                 Ext.Ajax.request({
@@ -166,10 +168,13 @@ pimcore.plugin.luceneSearch.settings = Class.create({
 
                                                         var res = Ext.decode(transport.responseText);
                                                         Ext.getCmp('stateMessage').setValue(_.parseState(res.state));
-                                                        _self.loadMask.hide();
 
                                                     }
                                                 });
+
+                                                window.setTimeout(function () {
+                                                    _self.loadMask.hide();
+                                                }, 2000);
                                             }
                                         });
                                     }.bind(this)
@@ -223,15 +228,6 @@ pimcore.plugin.luceneSearch.settings = Class.create({
                 run: this.updateCrawlerState.bind(_),
                 interval: 10000
             });
-
-            Ext.Ajax.request({
-                url: '/admin/lucene-search/settings/logs/get',
-                success: function(response){
-                    var data = Ext.decode(response.responseText);
-                    Ext.getCmp('lucenesearch_log_data').setValue(data.logData);
-                }
-            });
-
         }
 
         return this.panel;
@@ -254,6 +250,14 @@ pimcore.plugin.luceneSearch.settings = Class.create({
             }
         });
 
+        Ext.Ajax.request({
+            url: '/admin/lucene-search/settings/logs/get',
+            method: 'get',
+            success: function (response) {
+              var data = Ext.decode(response.responseText);
+              Ext.getCmp('lucenesearch_log_data').setValue(data.logData);
+            }
+        });
     },
 
     getData: function () {

--- a/src/LuceneSearchBundle/Task/Crawler/Listener/Abort.php
+++ b/src/LuceneSearchBundle/Task/Crawler/Listener/Abort.php
@@ -30,11 +30,13 @@ class Abort
     public function checkCrawlerState(Event $event)
     {
         if (!file_exists(Configuration::CRAWLER_PROCESS_FILE_PATH)) {
-            $this->spider->getDispatcher()->dispatch(LuceneSearchEvents::LUCENE_SEARCH_CRAWLER_INTERRUPTED,
+            $this->spider->getDispatcher()->dispatch(
                 new GenericEvent($this, [
                     'uri'          => $event->getArgument('uri'),
                     'errorMessage' => 'crawling aborted by user (tmp file while crawling has suddenly gone.)'
-                ]));
+                ]),
+                LuceneSearchEvents::LUCENE_SEARCH_CRAWLER_INTERRUPTED
+            );
         }
     }
 

--- a/src/LuceneSearchBundle/Task/Parser/ParserTask.php
+++ b/src/LuceneSearchBundle/Task/Parser/ParserTask.php
@@ -680,7 +680,7 @@ class ParserTask extends AbstractTask
             //try html lang attribute
             $languages = [];
             preg_match_all('@<html[\n|\r\n]*.*?[\n|\r\n]*lang="(?P<language>\S+)"[\n|\r\n]*.*?[\n|\r\n]*>@si', $body, $languages);
-            if ($languages['language']) {
+            if (isset($languages['language'])) {
                 $l = str_replace(['_', '-'], '', $languages['language'][0]);
             }
         }
@@ -689,7 +689,7 @@ class ParserTask extends AbstractTask
             //try meta tag
             $languages = [];
             preg_match_all('@<meta\shttp-equiv="content-language"\scontent="(?P<language>\S+)"\s\/>@si', $body, $languages);
-            if ($languages['language']) {
+            if (isset($languages['language'])) {
                 //for lucene index remove '_' - this causes tokenization
                 $l = str_replace('_', '', $languages['language'][0]);
             }
@@ -714,7 +714,7 @@ class ParserTask extends AbstractTask
             $data = [];
             preg_match('@.*?;\s*charset=(.*)\s*@si', $contentType, $data);
 
-            if ($data[1]) {
+            if (isset($data[1])) {
                 $encoding = trim($data[1]);
             }
         }
@@ -724,7 +724,7 @@ class ParserTask extends AbstractTask
             $data = [];
             preg_match('@<meta\shttp-equiv="Content-Type"\scontent=".*?;\s+charset=(.*?)"\s\/>@si', $body, $data);
 
-            if ($data[1]) {
+            if (isset($data[1])) {
                 $encoding = trim($data[1]);
             }
         }
@@ -734,7 +734,7 @@ class ParserTask extends AbstractTask
             $data = [];
             preg_match('@<\?xml.*?encoding="(.*?)"\s*\?>@si', $body, $data);
 
-            if ($data[1]) {
+            if (isset($data[1])) {
                 $encoding = trim($data[1]);
             }
         }
@@ -744,7 +744,7 @@ class ParserTask extends AbstractTask
             $data = [];
             preg_match('@<meta\scharset="(.*?)"\s*>@si', $body, $data);
 
-            if ($data[1]) {
+            if (isset($data[1])) {
                 $encoding = trim($data[1]);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | (https://github.com/pringuin/pimcore-lucene-search/issues/1)

I recently updated a Pimcore, which uses the pimcore-lucene-search bundle, from 11.2.x to 11.5.x.
Unfortunately the crawl ran into the following error:

![pimcore-lucene-search_undefined-array-key](https://github.com/user-attachments/assets/3d4c24b0-df63-4830-9599-0a43904fa914)

I have fixed this and other issues.
Now it is again possible to start and stop the crawl from the backend - as long as `.bin/console messenger:consume pimcore_maintenance` is running as a cronjob.  

**Tested on**
| System        | Version
| ------------- | ---
| PHP      | >= 8.2.25
| Pimcore  | 11.5.x

Bye Björn